### PR TITLE
Fix typo in readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,7 +34,7 @@ IniFile gem does all you need.
 
 Parsing an INI file is fairly simple:
 
-    IniParse.parse( File.open('path/to/my/file.ini') ) # => IniParse::Document
+    IniParse.parse( File.read('path/to/my/file.ini') ) # => IniParse::Document
 
 IniParse.parse returns an IniParse::Document instance which represents the
 passed "INI string". Assuming you know the structure of the document, you can


### PR DESCRIPTION
File.read instead of File.open - File.open returns a File object instead of its contents and breaks the script.
