### PR TITLE
Update parsing to handle multiple sections with the same name

### DIFF
--- a/lib/iniparse/generator.rb
+++ b/lib/iniparse/generator.rb
@@ -110,8 +110,13 @@ module IniParse
         raise LineNotAllowed, "You can't nest sections in INI files."
       end
 
-      @context = Lines::Section.new(name, line_options(opts))
-      @document.lines << @context
+      # Add to a section if it already exists
+      if @document.has_section?(name.to_s())
+        @context = @document[name.to_s()]
+      else
+        @context = Lines::Section.new(name, line_options(opts))
+        @document.lines << @context
+      end
 
       if block_given?
         begin


### PR DESCRIPTION
An INI file with multiple sections have the same name would fail to be parsed correctly. This fix will set the @context variable to the existing section object so that parsed options are properly added to it.
