### PR TITLE
Fixed saving duplicate options

### DIFF
--- a/iniparse.gemspec
+++ b/iniparse.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   ## the sub! line in the Rakefile
   s.name              = 'iniparse'
   s.version           = '1.3.3'
-  s.date              = '2015-03-24'
+  s.date              = '2015-03-25'
   s.rubyforge_project = 'iniparse'
 
   s.summary           = 'A pure Ruby library for parsing INI documents.'

--- a/iniparse.gemspec
+++ b/iniparse.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   ## the sub! line in the Rakefile
   s.name              = 'iniparse'
   s.version           = '1.3.3'
-  s.date              = '2014-10-30'
+  s.date              = '2015-03-24'
   s.rubyforge_project = 'iniparse'
 
   s.summary           = 'A pure Ruby library for parsing INI documents.'

--- a/lib/iniparse/lines.rb
+++ b/lib/iniparse/lines.rb
@@ -145,7 +145,7 @@ module IniParse
         opts = {}
         if line.kind_of?(Array)
           opts = line.first.options
-        else
+        elsif line.respond_to? :options
           opts = line.options
         end
         @lines[key.to_s] = IniParse::Lines::Option.new(key.to_s, value, opts)
@@ -290,7 +290,11 @@ module IniParse
       # returns an array to support multiple lines or a single one at once
       # because of options key duplication
       def line_contents
-        [*value].map { |v, i| "#{key} = #{v}" }
+        if value.kind_of?(Array)
+          value.map { |v, i| "#{key} = #{v}" }
+        else
+          "#{key} = #{value}"
+        end
       end
     end
 

--- a/lib/iniparse/lines.rb
+++ b/lib/iniparse/lines.rb
@@ -272,7 +272,12 @@ module IniParse
       #######
 
       def line_contents
-        '%s = %s' % [key, value]
+        contents = ''
+        [*value].each do |v|
+          contents << "#{key} = #{v}"
+          contents << "\n" if [*value].count > 1
+        end
+        contents
       end
     end
 


### PR DESCRIPTION
There is a bug in iniparse that prevent duplicate option keys to be saved properly.
While these options can be read as an array, they are saved under a single key containing the string representation of that array.

e.g.:
Given this ini file :
```
[settings]
ignore = alpha
ignore = beta
```

Using iniparse to modify ignore's second value to gamma will result in this after saving it : 

```
[settings]
ignore = ["alpha","gamma"]
```

This PR fixes this by expanding every element in the array to a separate line.