### PR TITLE
Drop EOL'd property rubyforge_project

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,10 +23,6 @@ def date
   Date.today.to_s
 end
 
-def rubyforge_project
-  name
-end
-
 def gemspec_file
   "#{name}.gemspec"
 end
@@ -77,8 +73,6 @@ task :gemspec => :validate do
   replace_header(head, :name)
   replace_header(head, :version)
   replace_header(head, :date)
-  #comment this out if your rubyforge_project has a different name
-  replace_header(head, :rubyforge_project)
 
   # determine file list from git ls-files
   files = `git ls-files`.

--- a/iniparse.gemspec
+++ b/iniparse.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.name              = 'iniparse'
   s.version           = '1.4.4'
   s.date              = '2017-07-04'
-  s.rubyforge_project = 'iniparse'
 
   s.summary           = 'A pure Ruby library for parsing INI documents.'
   s.authors           = ['Anthony Williams']


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.

Fixes Rakefile task AND gemspec.